### PR TITLE
Use promise-timeout instead of rolling our own timeout in invoke()

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "firefight": "1.x",
     "lodash": "^4.17.21",
     "lru-cache": "6.x",
-    "safe-timers": "^1.1.0"
+    "safe-timers": "^1.1.0",
+    "promise-timeout": "1.3.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.191",


### PR DESCRIPTION
From our email correspondence, so we can review in an actually useful tool (Reviewable!)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/27)
<!-- Reviewable:end -->
