### PR TITLE
Use safe-promise-tools instead of rolling our own timeout in invoke()

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "firefight": "1.x",
     "lodash": "^4.17.21",
     "lru-cache": "6.x",
+    "safe-timers": "^1.1.0",
     "safe-promise-tools": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "firefight": "1.x",
     "lodash": "^4.17.21",
     "lru-cache": "6.x",
-    "safe-timers": "^1.1.0",
-    "promise-timeout": "1.3.0"
+    "safe-promise-tools": "^3.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.191",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "firefight": "1.x",
     "lodash": "^4.17.21",
     "lru-cache": "6.x",
-    "safe-timers": "^1.1.0"
+    "safe-timers": "^1.1.0",
+    "promise-timeout": "1.3.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.191",

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -919,7 +919,7 @@ function handleError(error, op, callback) {
     ref: op.ref.toString(), method: op.method, args: argsToSentry,
     code: (error.code || error.message || '').toLowerCase() || undefined
   };
-  if (error.message === 'timeout' && error.timeout) {
+  if (error instanceof TimeoutError && error.timeout) {
     error.firebase.timeout = error.timeout;
     delete error.timeout;
   }

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -1,11 +1,11 @@
 import admin from 'firebase-admin';
-import {setTimeout, Timeout} from 'safe-timers';
+import {timeout, TimeoutError} from 'safe-promise-tools';
+import {setTimeout, type Timeout} from 'safe-timers';
 import _ from 'lodash';
 import LRUCache from 'lru-cache';
 import firebaseChildrenKeys from 'firebase-childrenkeys';
 import {Simulator} from 'firefight';
 import {Agent} from 'http';
-import { timeout, TimeoutError } from 'promise-timeout';
 
 export type InterceptOperationsCallback = (
   op: {ref: NodeFire, method: string, args: any[]},
@@ -903,7 +903,7 @@ function invoke(op, options: {timeout?: number} = {}, fn) {
       promise = timeout(promise, options.timeout);
     }
     return promise.catch(e => {
-      if (e.message === 'timeout') e.timeout = options.timeout;
+      if (e instanceof TimeoutError) e.timeout = options.timeout;
       return handleError(e, op, Promise.reject.bind(Promise));
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,6 +1836,13 @@ safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+safe-promise-tools@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/safe-promise-tools/-/safe-promise-tools-3.0.0.tgz#61adc3ecaa7bc5d38c9b3957fc391e1827ceb705"
+  integrity sha512-oHMyE230HDSzf7tpIxgql8j8Q/uyuUT021+x8WwYm47RMPZyrFpVKHiRA/H0XcHiPaahFRC5sBGgSE4A8kykBw==
+  dependencies:
+    safe-timers "^1.1.0"
+
 safe-timers@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-timers/-/safe-timers-1.1.0.tgz#c58ae8325db8d3b067322f0a4ef3a0cad67aad83"


### PR DESCRIPTION
I was going to use promise-tools, but you wanted safe-timers so I forked it upstream and made a safe-promise-tools that was basically the same thing.

The main point of this PR isn't to reduce line count, but to reduce complexity. The `invoke()` function was previously doing, according to what I can gather, the following tasks:
* Allow a global interceptors list of possibly-async functions to run before the actual operation
* run the operation in a Promise
* timeout the operation through a complicated setTimeout/settled combination to handle possible async gotchas (one Promise resolving before another starts)
* Attach the `timeout` prop if there was a timeout

That's a lot of stuff, and the timeout operation was the most complicated and fraught, so I pulled it out and used a simpler mechanism. While, notably, `safe-promise-tools` is not a small library, it generally converts annoying async operations into named functions that operate as you expect.

If there was a standard for cancellable promises in JS, I personally would rather use `delay` than `setTimeout` in all JS/TS code going forward. Unfortunately, I don't see a standard one (yet)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/29)
<!-- Reviewable:end -->
