### PR TITLE
Don't cache queries.

### DIFF
--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -256,10 +256,12 @@ export default class NodeFire {
   }
 
   /**
-   * Adds this reference to the cache (if maxCacheSize set) and counts a cache hit or miss.
+   * Adds this reference (if it's not a query) to the cache (if maxCacheSize set) and counts a cache
+   * hit or miss.
    */
   cache(): void {
     if (!cache) return;
+    if (!this.$ref.isEqual(this.$ref.ref)) return;  // don't cache queries
     const key = this.database.app.name + '/' + this.path;
     if (cache.has(key)) {
       cacheHits++;


### PR DESCRIPTION
1. It's not likely to be useful, since query params change often.
2. We were using a key that didn't include the query params anyway.
3. I suspect caching queries exposes a bug in Firebase that returns incomplete results for normal fetches at similar paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/31)
<!-- Reviewable:end -->
