### PR TITLE
Always retain the original args array on the exception.

### DIFF
--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -945,11 +945,9 @@ function invoke(op, options: {timeout?: number} = {}, fn) {
 function handleError(error, op, callback) {
   const args: any[] = _.map(
     op.args, arg => _.isFunction(arg) ? `<function${arg.name ? ' ' + arg.name : ''}>` : arg);
-  const argsString = JSON.stringify(args);
-  const argsToSentry: any[] | string =
-    argsString.length > 500 ? argsString.slice(0, 500) + '...' : args;
+
   error.firebase = {
-    ref: op.ref.toString(), method: op.method, args: argsToSentry,
+    ref: op.ref.toString(), method: op.method, args,
     code: (error.code || error.message || '').toLowerCase() || undefined
   };
   if (error.message === 'timeout' && error.timeout) {


### PR DESCRIPTION
Let the caller deal with it if it's too much.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/36)
<!-- Reviewable:end -->
