### PR TITLE
Redefine Value type as NonNullable<unknown>|null

### DIFF
--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -12,14 +12,7 @@ export type InterceptOperationsCallback = (
 ) => Promise<void> | void;
 
 export type PrimitiveValue = string | number | boolean | null;
-export type Value = PrimitiveValue | {[key: string]: Value};
-// The precise type defintion is commented out below. We do not use it (at least yet)
-// because it would require us to add a fair amount of boilerplate to our loosely
-// typed code base at Reviewable. That is because you cannot access properties of
-// a union type with no common subset until you cast it to a more specfic type (or any).
-// This wouldn't be an issue though in a project with complete type definitions as you
-// would cast the data read from Firebase to the respecitve interface anyway.
-// export type StoredValue = PrimitiveValue | {[key: string]: NonNullable<StoredValue>};
+export type Value = NonNullable<unknown> | null;
 export type StoredValue = any;
 
 let cache: any, cacheHits = 0, cacheMisses = 0, maxCacheSizeForDisconnectedApp = Infinity;


### PR DESCRIPTION
The previous type defintion involved an index signature, and therefore any compatible object type was required to have an index signature which made it incompatible with most object types. The idea was to guard against objects that have a property with the value of undefined somewhere down their object tree. But as it turns out this isn't possible without causing false negatives, this was a mistake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/41)
<!-- Reviewable:end -->
