### PR TITLE
Add after-operation interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,14 @@ enablePermissionDebugging(legacySecret)
  * Adds an intercepting callback before or after all NodeFire database operations.
  * @param {Function} callback The callback to invoke.  It will be passed an operation descriptor
  *     ({ref, method, args}) and the operation's options object.  Before callbacks can modify the
- *     options.  After callbacks receive the same descriptor decorated with `startTime`, `duration`,
- *     optional `error`, and transaction metadata.  Transaction duration is averaged across its
- *     tries.  A returned promise blocks the operation from advancing past the selected trigger
- *     until it settles.  If an after callback fails after a successful operation, its error is
- *     propagated to the caller.  If both the operation and an after callback fail, the operation
- *     error is retained and the callback error is attached as its `cause` (or `interceptorError`
- *     if it already had a cause).
+ *     options.  After callbacks receive the same descriptor decorated with optional `startTime`,
+ *     `duration`, `error`, and transaction metadata.  Transaction duration excludes prefetch and
+ *     is averaged across its tries; `startTime` and `duration` are omitted if no try was started.
+ *     A returned promise blocks the operation from advancing past the selected trigger until it
+ *     settles.  If an after callback fails after a successful operation, its error is propagated
+ *     to the caller.  If both the operation and an after callback fail, the operation error is
+ *     retained and the callback error is attached as its `cause` (or `interceptorError` if it
+ *     already had a cause).
  * @param {'before' | 'after'} trigger The callback trigger.  Defaults to `before`.
  */
 static interceptOperations(callback, trigger = 'before')

--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ enablePermissionDebugging(legacySecret)
  *     options.  After callbacks receive the same descriptor decorated with `startTime`, `duration`,
  *     optional `error`, and transaction metadata.  Transaction duration is averaged across its
  *     tries.  A returned promise blocks the operation from advancing past the selected trigger
- *     until it settles.  If both the operation and an after callback fail, the operation error is
- *     retained and the callback error is attached as its `cause` (or `interceptorError` if it
- *     already had a cause).
+ *     until it settles.  If an after callback fails after a successful operation, its error is
+ *     propagated to the caller.  If both the operation and an after callback fail, the operation
+ *     error is retained and the callback error is attached as its `cause` (or `interceptorError`
+ *     if it already had a cause).
  * @param {'before' | 'after'} trigger The callback trigger.  Defaults to `before`.
- * @return {Function} An idempotent function that removes the callback.
  */
 static interceptOperations(callback, trigger = 'before')
 

--- a/README.md
+++ b/README.md
@@ -131,15 +131,19 @@ static enableFirebaseLogging(enable)
 enablePermissionDebugging(legacySecret)
 
 /**
- * Adds an intercepting callback before all NodeFire database operations.  This callback can
- * modify the operation's options or block it while performing other work.
- * @param {Function} callback The callback to invoke before each operation.  It will be passed two
- *     arguments: an operation descriptor ({ref, method, args}) and an options object.  The
- *     descriptor is read-only but the options can be modified.  The callback can return any value
- *     (which will be ignored) or a promise, to block execution of the operation (but not other
- *     interceptors) until the promise settles.
+ * Adds an intercepting callback before or after all NodeFire database operations.
+ * @param {Function} callback The callback to invoke.  It will be passed an operation descriptor
+ *     ({ref, method, args}) and the operation's options object.  Before callbacks can modify the
+ *     options.  After callbacks receive the same descriptor decorated with `startTime`, `duration`,
+ *     optional `error`, and transaction metadata.  Transaction duration is averaged across its
+ *     tries.  A returned promise blocks the operation from advancing past the selected trigger
+ *     until it settles.  If both the operation and an after callback fail, the operation error is
+ *     retained and the callback error is attached as its `cause` (or `interceptorError` if it
+ *     already had a cause).
+ * @param {'before' | 'after'} trigger The callback trigger.  Defaults to `before`.
+ * @return {Function} An idempotent function that removes the callback.
  */
-static interceptOperations(callback)
+static interceptOperations(callback, trigger = 'before')
 
 /**
  * Sets the maximum number of values to keep pinned and updated in the cache.  The cache is not used

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ enablePermissionDebugging(legacySecret)
  * @param {Function} callback The callback to invoke.  It will be passed an operation descriptor
  *     ({ref, method, args}) and the operation's options object.  Before callbacks can modify the
  *     options.  After callbacks receive the same descriptor decorated with optional `startTime`,
- *     `duration`, `error`, and transaction metadata.  Transaction duration excludes prefetch and
- *     is averaged across its tries; `startTime` and `duration` are omitted if no try was started.
+ *     `duration`, `error`, and transaction metadata.  Transaction duration excludes prefetch;
+ *     `startTime` and `duration` are omitted if no try was started.
  *     A returned promise blocks the operation from advancing past the selected trigger until it
  *     settles.  If an after callback fails after a successful operation, its error is propagated
  *     to the caller.  If both the operation and an after callback fail, the operation error is

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/safe-timers": "^1.1.0",
     "eslint": "^10.7.0",
     "npm-check-updates": "^22.2.9",
-    "reviewable-configs": "Reviewable/reviewable-configs#master",
+    "reviewable-configs": "github:Reviewable/reviewable-configs#master",
     "typescript": "^5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodefire",
-  "version": "7.1.3",
+  "version": "7.2.0",
   "description": "A promise-centric Firebase library for NodeJS",
   "main": "built/index.js",
   "types": "built/index.d.ts",
@@ -18,7 +18,7 @@
     "lint": "eslint src/*.ts tests/*.ts tests/*.mjs",
     "check-types": "tsc --noEmit --skipLibCheck && tsc --project tests/tsconfig.json --skipLibCheck",
     "build": "tsc",
-    "test": "yarn build && node --test tests/cache.mjs",
+    "test": "yarn build && node --test tests/*.mjs",
     "prepack": "tsc"
   },
   "repository": "https://github.com/Reviewable/nodefire",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodefire",
-  "version": "7.1.2",
+  "version": "7.2.0",
   "description": "A promise-centric Firebase library for NodeJS",
   "main": "built/index.js",
   "types": "built/index.d.ts",
@@ -18,7 +18,7 @@
     "lint": "eslint src/*.ts tests/*.ts tests/*.mjs",
     "check-types": "tsc --noEmit --skipLibCheck && tsc --project tests/tsconfig.json --skipLibCheck",
     "build": "tsc",
-    "test": "yarn build && node --test tests/cache.mjs",
+    "test": "yarn build && node --test tests/*.mjs",
     "prepack": "tsc"
   },
   "repository": "https://github.com/Reviewable/nodefire",

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -19,10 +19,26 @@ interface NodeFireTypeCarrier {
 
 type AnyNodeFire = NodeFire<any, any, any>;
 
+export interface OperationDescriptor {
+  readonly ref: AnyNodeFire;
+  readonly method: string;
+  readonly args: any[];
+  /** `performance.now()` when the Firebase operation started.  Only present after completion. */
+  readonly startTime?: number;
+  /** Firebase operation duration in milliseconds.  Transactions report the average per try. */
+  readonly duration?: number;
+  /** The operation error, if any.  Only present after completion. */
+  readonly error?: Error;
+  /** Transaction metadata, only present for transactions after completion. */
+  readonly transaction?: TransactionMetadata;
+}
+
 export type InterceptOperationsCallback = (
-  op: {ref: AnyNodeFire, method: string, args: any[]},
+  op: OperationDescriptor,
   options: any
 ) => Promise<void> | void;
+
+export type OperationInterceptorTrigger = 'before' | 'after';
 
 export type PrimitiveValue = string | number | boolean | null;
 export interface Info {
@@ -51,14 +67,18 @@ export interface CacheStats {
 let cache: LRUCache<string, AnyNodeFire> | null;
 let cacheHits = 0, cacheMisses = 0;
 const serverTimeOffsets = {}, serverDisconnects = {}, simulators = {};
-const operationInterceptors: InterceptOperationsCallback[] = [];
+const operationInterceptors: Record<OperationInterceptorTrigger, InterceptOperationsCallback[]> = {
+  before: [], after: []
+};
 
 export interface Scope {
   [key: string]: any;
 }
 
 export interface NodeFireError extends Error {
+  cause?: unknown;
   inputValues?: any;
+  interceptorError?: unknown;
   timeout?: number;
 }
 
@@ -496,7 +516,7 @@ export default class NodeFire<
     const self = this;  // easier than using => functions or binding explicitly
     options = options ?? {};
     let tries = 0, result: any;
-    const startTime = self.now;
+    const startTime = performance.now();
     let prefetchDoneTime: number;
     const metadata: TransactionMetadata = {};
 
@@ -506,17 +526,18 @@ export default class NodeFire<
       metadata.tries = tries;
       if (prefetchDoneTime) {
         metadata.prefetchDuration = prefetchDoneTime - startTime;
-        metadata.duration = self.now - prefetchDoneTime;
+        metadata.duration = performance.now() - prefetchDoneTime;
       } else {
-        metadata.duration = self.now - startTime;
+        metadata.duration = performance.now() - startTime;
       }
     }
 
-    const op = {ref: this, method: 'transaction', args: [updateFunction]};
+    const op: OperationDescriptor = {ref: this, method: 'transaction', args: [updateFunction]};
+    let operationStartTime: number | undefined;
 
     const promise = Promise.all(
       _.map(
-        operationInterceptors,
+        operationInterceptors.before,
         (interceptor: InterceptOperationsCallback) => Promise.resolve(interceptor(op, options))
       )
     ).then(() => {
@@ -564,7 +585,8 @@ export default class NodeFire<
 
         let onceTxn, timeout: Timeout;
         function txn() {
-          if (!prefetchDoneTime) prefetchDoneTime = self.now;
+          if (!prefetchDoneTime) prefetchDoneTime = performance.now();
+          operationStartTime ??= prefetchDoneTime;
           try {
             self.$ref.ref.transaction(wrappedUpdateFunction, (error, committed, snap) => {
               if (error && (error.message === 'set' || error.message === 'disconnect')) {
@@ -613,7 +635,22 @@ export default class NodeFire<
           txn();
         }
       });
-    });
+    }).then(
+      async value => {
+        await interceptCompletedOperation(
+          op, options!, operationStartTime, metadata.tries, undefined, metadata);
+        return value;
+      },
+      async error => {
+        try {
+          await interceptCompletedOperation(
+            op, options!, operationStartTime, metadata.tries, error, metadata);
+        } catch (interceptorError) {
+          attachInterceptorError(error, interceptorError);
+        }
+        throw error;
+      }
+    );
     return _.assign(promise, {transaction: metadata});
   }
 
@@ -719,17 +756,30 @@ export default class NodeFire<
   }
 
   /**
-   * Adds an intercepting callback before all NodeFire database operations.  This callback can
-   * modify the operation's options or block it while performing other work.
+   * Adds an intercepting callback before or after all NodeFire database operations.  A before
+   * callback can modify the operation's options or block it while performing other work.  An after
+   * callback receives the same operation descriptor decorated with completion details.
    * @param callback
-   *     The callback to invoke before each operation.  It will be passed two
-   *     arguments: an operation descriptor ({ref, method, args}) and an options object.  The
-   *     descriptor is read-only but the options can be modified.  The callback can return any value
-   *     (which will be ignored) or a promise, to block execution of the operation (but not other
-   *     interceptors) until the promise settles.
+   *     The callback to invoke.  It will be passed two arguments: an operation descriptor and an
+   *     options object.  The descriptor is read-only but before callbacks can modify the options.
+   *     The callback can return any value (which will be ignored) or a promise, to block the
+   *     operation from advancing past this trigger (but not other interceptors) until it settles.
+   * @param trigger Whether to invoke the callback before or after operations.  Defaults to before.
+   * @return An idempotent function that removes the callback.
    */
-  static interceptOperations(callback: InterceptOperationsCallback): void {
-    operationInterceptors.push(callback);
+  static interceptOperations(
+    callback: InterceptOperationsCallback,
+    trigger: OperationInterceptorTrigger = 'before'
+  ): () => void {
+    const interceptors = operationInterceptors[trigger];
+    if (!interceptors) {
+      throw new Error('Operation interceptor trigger must be \'before\' or \'after\'');
+    }
+    interceptors.push(callback);
+    return _.once(() => {
+      const index = interceptors.indexOf(callback);
+      if (index >= 0) interceptors.splice(index, 1);
+    });
   }
 
   /**
@@ -1058,11 +1108,9 @@ function getNormalRawValue<T>(value: T): ReadValue<T> {
 function invoke(op, options: {timeout?: number} = {}, fn) {
   options = options ?? {};
   return Promise.all(
-    _.map(
-      operationInterceptors,
-      interceptor => Promise.resolve(interceptor(op, options))
-    )
+    _.map(operationInterceptors.before, interceptor => Promise.resolve(interceptor(op, options)))
   ).then(() => {
+    const startTime = performance.now();
     const promises: Promise<void>[] = [];
     let timeout: Timeout | undefined, settled = false;
     if (options.timeout) {
@@ -1077,13 +1125,53 @@ function invoke(op, options: {timeout?: number} = {}, fn) {
       if (timeout) timeout.clear();
       return result;
     }));
-    return Promise.race(promises).catch(e => {
+    const promise = Promise.race(promises).catch(e => {
       settled = true;
       if (timeout) timeout.clear();
       if (e.message === 'timeout') e.timeout = options.timeout;
       return handleError(e, op, Promise.reject.bind(Promise));
     });
+    return promise.then(
+      async value => {
+        await interceptCompletedOperation(op, options, startTime);
+        return value;
+      },
+      async error => {
+        try {
+          await interceptCompletedOperation(op, options, startTime, undefined, error);
+        } catch (interceptorError) {
+          attachInterceptorError(error, interceptorError);
+        }
+        throw error;
+      }
+    );
   });
+}
+
+async function interceptCompletedOperation(
+  op: OperationDescriptor,
+  options: any,
+  startTime = performance.now(),
+  tries?: number,
+  error?: Error,
+  transaction?: TransactionMetadata
+) {
+  const elapsed = performance.now() - startTime;
+  _.assign(op, {
+    startTime,
+    duration: elapsed / (tries || 1),
+    ...error && {error},
+    ...transaction && {transaction}
+  });
+  await Promise.all(_.map(
+    operationInterceptors.after,
+    interceptor => Promise.resolve(interceptor(op, options))
+  ));
+}
+
+function attachInterceptorError(error: NodeFireError, interceptorError: unknown) {
+  if (error.cause === undefined) error.cause = interceptorError;
+  else error.interceptorError = interceptorError;
 }
 
 function handleError(error, op, callback) {

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -23,9 +23,9 @@ export interface OperationDescriptor {
   readonly ref: AnyNodeFire;
   readonly method: string;
   readonly args: any[];
-  /** `performance.now()` when the Firebase operation started.  Only present after completion. */
+  /** `performance.now()` when the Firebase operation started, if it was attempted. */
   readonly startTime?: number;
-  /** Firebase operation duration in milliseconds.  Transactions report the average per try. */
+  /** Firebase operation duration in milliseconds, if attempted.  Transactions average per try. */
   readonly duration?: number;
   /** The operation error, if any.  Only present after completion. */
   readonly error?: Error;
@@ -86,6 +86,7 @@ export interface TransactionMetadata {
   outcome?: 'commit' | 'error' | 'skip';
   tries?: number;
   prefetchDuration?: number;
+  /** Firebase transaction duration, excluding prefetch; absent if no transaction was attempted. */
   duration?: number;
 }
 
@@ -517,24 +518,21 @@ export default class NodeFire<
     options = options ?? {};
     let tries = 0, result: any;
     const startTime = performance.now();
-    let prefetchDoneTime: number;
+    let prefetchDoneTime: number | undefined;
     const metadata: TransactionMetadata = {};
 
     function fillMetadata(outcome: NonNullable<TransactionMetadata['outcome']>) {
       if (metadata.outcome) return;
       metadata.outcome = outcome;
       metadata.tries = tries;
-      if (prefetchDoneTime) {
+      if (prefetchDoneTime !== undefined) {
         metadata.prefetchDuration = prefetchDoneTime - startTime;
         metadata.duration = performance.now() - prefetchDoneTime;
-      } else {
-        metadata.duration = performance.now() - startTime;
       }
     }
 
     type OperationResult = ReadValue<Root> | null | undefined;
     const op: OperationDescriptor = {ref: this, method: 'transaction', args: [updateFunction]};
-    let operationStartTime: number | undefined;
 
     const promise = runOperationInterceptors('before', op, options).then(() => {
       const operationPromise = new Promise<OperationResult>((resolve, reject) => {
@@ -581,8 +579,7 @@ export default class NodeFire<
 
         let onceTxn, timeout: Timeout;
         function txn() {
-          if (!prefetchDoneTime) prefetchDoneTime = performance.now();
-          operationStartTime ??= prefetchDoneTime;
+          prefetchDoneTime ??= performance.now();
           try {
             self.$ref.ref.transaction(wrappedUpdateFunction, (error, committed, snap) => {
               if (error && (error.message === 'set' || error.message === 'disconnect')) {
@@ -634,13 +631,13 @@ export default class NodeFire<
       return operationPromise.then(
         async value => {
           await interceptCompletedOperation(
-            op, options!, operationStartTime, metadata.tries, undefined, undefined, metadata);
+            op, options!, prefetchDoneTime, metadata.tries, undefined, undefined, metadata);
           return value;
         },
         async error => {
           try {
             await interceptCompletedOperation(
-              op, options!, operationStartTime, metadata.tries, error, undefined, metadata);
+              op, options!, prefetchDoneTime, metadata.tries, error, undefined, metadata);
           } catch (interceptorError) {
             attachInterceptorError(error, interceptorError);
           }
@@ -1152,16 +1149,18 @@ function invoke(op, options: {timeout?: number} = {}, fn) {
 async function interceptCompletedOperation(
   op: OperationDescriptor,
   options: any,
-  startTime = performance.now(),
+  startTime?: number,
   tries?: number,
   error?: Error,
   endTime = performance.now(),
   transaction?: TransactionMetadata
 ) {
-  const elapsed = transaction?.duration ?? endTime - startTime;
-  _.assign(op, {
+  const timing = startTime === undefined ? {} : {
     startTime,
-    duration: elapsed / (tries || 1),
+    duration: (transaction?.duration ?? endTime - startTime) / (tries || 1)
+  };
+  _.assign(op, {
+    ...timing,
     ...error && {error},
     ...transaction && {transaction}
   });

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -639,13 +639,13 @@ export default class NodeFire<
       return operationPromise.then(
         async value => {
           await interceptCompletedOperation(
-            op, options!, operationStartTime, metadata.tries, undefined, metadata);
+            op, options!, operationStartTime, metadata.tries, undefined, undefined, metadata);
           return value;
         },
         async error => {
           try {
             await interceptCompletedOperation(
-              op, options!, operationStartTime, metadata.tries, error, metadata);
+              op, options!, operationStartTime, metadata.tries, error, undefined, metadata);
           } catch (interceptorError) {
             attachInterceptorError(error, interceptorError);
           }
@@ -1125,20 +1125,28 @@ function invoke(op, options: {timeout?: number} = {}, fn) {
       if (timeout) timeout.clear();
       return result;
     }));
-    const promise = Promise.race(promises).catch(e => {
-      settled = true;
-      if (timeout) timeout.clear();
-      if (e.message === 'timeout') e.timeout = options.timeout;
-      return handleError(e, op, Promise.reject.bind(Promise));
-    });
+    let endTime = startTime;
+    const promise = Promise.race(promises).then(
+      value => {
+        endTime = performance.now();
+        return value;
+      },
+      e => {
+        endTime = performance.now();
+        settled = true;
+        if (timeout) timeout.clear();
+        if (e.message === 'timeout') e.timeout = options.timeout;
+        return handleError(e, op, Promise.reject.bind(Promise));
+      }
+    );
     return promise.then(
       async value => {
-        await interceptCompletedOperation(op, options, startTime);
+        await interceptCompletedOperation(op, options, startTime, undefined, undefined, endTime);
         return value;
       },
       async error => {
         try {
-          await interceptCompletedOperation(op, options, startTime, undefined, error);
+          await interceptCompletedOperation(op, options, startTime, undefined, error, endTime);
         } catch (interceptorError) {
           attachInterceptorError(error, interceptorError);
         }
@@ -1154,9 +1162,10 @@ async function interceptCompletedOperation(
   startTime = performance.now(),
   tries?: number,
   error?: Error,
+  endTime = performance.now(),
   transaction?: TransactionMetadata
 ) {
-  const elapsed = performance.now() - startTime;
+  const elapsed = transaction?.duration ?? endTime - startTime;
   _.assign(op, {
     startTime,
     duration: elapsed / (tries || 1),

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -532,6 +532,7 @@ export default class NodeFire<
       }
     }
 
+    type OperationResult = ReadValue<Root> | null | undefined;
     const op: OperationDescriptor = {ref: this, method: 'transaction', args: [updateFunction]};
     let operationStartTime: number | undefined;
 
@@ -541,7 +542,7 @@ export default class NodeFire<
         (interceptor: InterceptOperationsCallback) => Promise.resolve(interceptor(op, options))
       )
     ).then(() => {
-      return new Promise<ReadValue<Root> | null | undefined>((resolve, reject) => {
+      const operationPromise = new Promise<OperationResult>((resolve, reject) => {
         const wrappedRejectNoResult = wrapReject(self, 'transaction', reject);
         let wrappedReject = wrappedRejectNoResult;
         let aborted = false, settled = false;
@@ -635,22 +636,23 @@ export default class NodeFire<
           txn();
         }
       });
-    }).then(
-      async value => {
-        await interceptCompletedOperation(
-          op, options!, operationStartTime, metadata.tries, undefined, metadata);
-        return value;
-      },
-      async error => {
-        try {
+      return operationPromise.then(
+        async value => {
           await interceptCompletedOperation(
-            op, options!, operationStartTime, metadata.tries, error, metadata);
-        } catch (interceptorError) {
-          attachInterceptorError(error, interceptorError);
+            op, options!, operationStartTime, metadata.tries, undefined, metadata);
+          return value;
+        },
+        async error => {
+          try {
+            await interceptCompletedOperation(
+              op, options!, operationStartTime, metadata.tries, error, metadata);
+          } catch (interceptorError) {
+            attachInterceptorError(error, interceptorError);
+          }
+          throw error;
         }
-        throw error;
-      }
-    );
+      );
+    });
     return _.assign(promise, {transaction: metadata});
   }
 
@@ -764,22 +766,20 @@ export default class NodeFire<
    *     options object.  The descriptor is read-only but before callbacks can modify the options.
    *     The callback can return any value (which will be ignored) or a promise, to block the
    *     operation from advancing past this trigger (but not other interceptors) until it settles.
+   *     If an after callback fails after a successful operation, its error is propagated to the
+   *     caller.  If the operation also failed, its original error is preserved and the callback
+   *     error is attached to it.
    * @param trigger Whether to invoke the callback before or after operations.  Defaults to before.
-   * @return An idempotent function that removes the callback.
    */
   static interceptOperations(
     callback: InterceptOperationsCallback,
     trigger: OperationInterceptorTrigger = 'before'
-  ): () => void {
+  ): void {
     const interceptors = operationInterceptors[trigger];
     if (!interceptors) {
       throw new Error('Operation interceptor trigger must be \'before\' or \'after\'');
     }
     interceptors.push(callback);
-    return _.once(() => {
-      const index = interceptors.indexOf(callback);
-      if (index >= 0) interceptors.splice(index, 1);
-    });
   }
 
   /**

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -536,12 +536,7 @@ export default class NodeFire<
     const op: OperationDescriptor = {ref: this, method: 'transaction', args: [updateFunction]};
     let operationStartTime: number | undefined;
 
-    const promise = Promise.all(
-      _.map(
-        operationInterceptors.before,
-        (interceptor: InterceptOperationsCallback) => Promise.resolve(interceptor(op, options))
-      )
-    ).then(() => {
+    const promise = runOperationInterceptors('before', op, options).then(() => {
       const operationPromise = new Promise<OperationResult>((resolve, reject) => {
         const wrappedRejectNoResult = wrapReject(self, 'transaction', reject);
         let wrappedReject = wrappedRejectNoResult;
@@ -1107,9 +1102,7 @@ function getNormalRawValue<T>(value: T): ReadValue<T> {
 
 function invoke(op, options: {timeout?: number} = {}, fn) {
   options = options ?? {};
-  return Promise.all(
-    _.map(operationInterceptors.before, interceptor => Promise.resolve(interceptor(op, options)))
-  ).then(() => {
+  return runOperationInterceptors('before', op, options).then(() => {
     const startTime = performance.now();
     const promises: Promise<void>[] = [];
     let timeout: Timeout | undefined, settled = false;
@@ -1172,9 +1165,17 @@ async function interceptCompletedOperation(
     ...error && {error},
     ...transaction && {transaction}
   });
-  await Promise.all(_.map(
-    operationInterceptors.after,
-    interceptor => Promise.resolve(interceptor(op, options))
+  await runOperationInterceptors('after', op, options);
+}
+
+function runOperationInterceptors(
+  trigger: OperationInterceptorTrigger,
+  op: OperationDescriptor,
+  options: any
+) {
+  return Promise.all(_.map(
+    operationInterceptors[trigger],
+    interceptor => Promise.resolve().then(() => interceptor(op, options))
   ));
 }
 

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -1172,11 +1172,21 @@ function runOperationInterceptors(
   trigger: OperationInterceptorTrigger,
   op: OperationDescriptor,
   options: any
-) {
-  return Promise.all(_.map(
+): Promise<void> {
+  const promises = _.map(
     operationInterceptors[trigger],
-    interceptor => Promise.resolve().then(() => interceptor(op, options))
-  ));
+    interceptor => Promise.resolve()
+      .then(() => interceptor(op, options))
+      .then(
+        () => ({rejected: false as const}),
+        error => ({rejected: true as const, error})
+      )
+  );
+  return Promise.all(promises).then(results => {
+    for (const result of results) {
+      if (result.rejected) throw result.error;
+    }
+  });
 }
 
 function attachInterceptorError(error: NodeFireError, interceptorError: unknown) {

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -582,6 +582,7 @@ export default class NodeFire<
 
         let onceTxn, timeout: Timeout;
         function txn() {
+          if (aborted) return;
           transactionStartTime ??= performance.now();
           try {
             self.$ref.ref.transaction(wrappedUpdateFunction, (error, committed, snap) => {
@@ -615,6 +616,7 @@ export default class NodeFire<
           timeout = setTimeout(() => {
             if (settled) return;
             aborted = true;
+            if (onceTxn) self.$ref.off('value', onceTxn);
             fillMetadata('error');
             wrappedReject(_.assign(new Error('timeout'), {options, op}));
           }, options.timeout);

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -25,7 +25,7 @@ export interface OperationDescriptor {
   readonly args: any[];
   /** `performance.now()` when the Firebase operation started, if it was attempted. */
   readonly startTime?: number;
-  /** Firebase operation duration in milliseconds, if attempted.  Transactions average per try. */
+  /** Firebase operation duration in milliseconds, if attempted. */
   readonly duration?: number;
   /** The operation error, if any.  Only present after completion. */
   readonly error?: Error;
@@ -85,6 +85,7 @@ export interface NodeFireError extends Error {
 export interface TransactionMetadata {
   outcome?: 'commit' | 'error' | 'skip';
   tries?: number;
+  /** Prefetch duration in milliseconds, if prefetching was attempted. */
   prefetchDuration?: number;
   /** Firebase transaction duration, excluding prefetch; absent if no transaction was attempted. */
   duration?: number;
@@ -518,23 +519,25 @@ export default class NodeFire<
     options = options ?? {};
     let tries = 0, result: any;
     const startTime = performance.now();
-    let prefetchDoneTime: number | undefined;
+    let transactionStartTime: number | undefined;
     const metadata: TransactionMetadata = {};
-
-    function fillMetadata(outcome: NonNullable<TransactionMetadata['outcome']>) {
-      if (metadata.outcome) return;
-      metadata.outcome = outcome;
-      metadata.tries = tries;
-      if (prefetchDoneTime !== undefined) {
-        metadata.prefetchDuration = prefetchDoneTime - startTime;
-        metadata.duration = performance.now() - prefetchDoneTime;
-      }
-    }
 
     type OperationResult = ReadValue<Root> | null | undefined;
     const op: OperationDescriptor = {ref: this, method: 'transaction', args: [updateFunction]};
 
     const promise = runOperationInterceptors('before', op, options).then(() => {
+      const prefetch = options!.prefetchValue ?? true;
+      function fillMetadata(outcome: NonNullable<TransactionMetadata['outcome']>) {
+        if (metadata.outcome) return;
+        const endTime = performance.now();
+        metadata.outcome = outcome;
+        metadata.tries = tries;
+        if (prefetch) {
+          metadata.prefetchDuration = (transactionStartTime ?? endTime) - startTime;
+        }
+        if (transactionStartTime !== undefined) metadata.duration = endTime - transactionStartTime;
+      }
+
       const operationPromise = new Promise<OperationResult>((resolve, reject) => {
         const wrappedRejectNoResult = wrapReject(self, 'transaction', reject);
         let wrappedReject = wrappedRejectNoResult;
@@ -579,7 +582,7 @@ export default class NodeFire<
 
         let onceTxn, timeout: Timeout;
         function txn() {
-          prefetchDoneTime ??= performance.now();
+          transactionStartTime ??= performance.now();
           try {
             self.$ref.ref.transaction(wrappedUpdateFunction, (error, committed, snap) => {
               if (error && (error.message === 'set' || error.message === 'disconnect')) {
@@ -616,14 +619,17 @@ export default class NodeFire<
             wrappedReject(_.assign(new Error('timeout'), {options, op}));
           }, options.timeout);
         }
-        if (options?.prefetchValue || options?.prefetchValue === undefined) {
+        if (prefetch) {
           // Prefetch the data and keep it "live" during the transaction, to avoid running the
           // (potentially expensive) transaction code 2 or 3 times while waiting for authoritative
           // data from the server.  Also pull it into the cache to speed future transactions at
           // this ref.
           self.cache();
           onceTxn = _.once(txn);
-          self.$ref.on('value', onceTxn, wrappedRejectNoResult);
+          self.$ref.on('value', onceTxn, error => {
+            fillMetadata('error');
+            wrappedRejectNoResult(error);
+          });
         } else {
           txn();
         }
@@ -631,13 +637,13 @@ export default class NodeFire<
       return operationPromise.then(
         async value => {
           await interceptCompletedOperation(
-            op, options!, prefetchDoneTime, metadata.tries, undefined, undefined, metadata);
+            op, options!, transactionStartTime, undefined, undefined, metadata);
           return value;
         },
         async error => {
           try {
             await interceptCompletedOperation(
-              op, options!, prefetchDoneTime, metadata.tries, error, undefined, metadata);
+              op, options!, transactionStartTime, error, undefined, metadata);
           } catch (interceptorError) {
             attachInterceptorError(error, interceptorError);
           }
@@ -1131,12 +1137,12 @@ function invoke(op, options: {timeout?: number} = {}, fn) {
     );
     return promise.then(
       async value => {
-        await interceptCompletedOperation(op, options, startTime, undefined, undefined, endTime);
+        await interceptCompletedOperation(op, options, startTime, undefined, endTime);
         return value;
       },
       async error => {
         try {
-          await interceptCompletedOperation(op, options, startTime, undefined, error, endTime);
+          await interceptCompletedOperation(op, options, startTime, error, endTime);
         } catch (interceptorError) {
           attachInterceptorError(error, interceptorError);
         }
@@ -1150,14 +1156,13 @@ async function interceptCompletedOperation(
   op: OperationDescriptor,
   options: any,
   startTime?: number,
-  tries?: number,
   error?: Error,
   endTime = performance.now(),
   transaction?: TransactionMetadata
 ) {
   const timing = startTime === undefined ? {} : {
     startTime,
-    duration: (transaction?.duration ?? endTime - startTime) / (tries || 1)
+    duration: transaction?.duration ?? endTime - startTime
   };
   _.assign(op, {
     ...timing,

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -1175,16 +1175,11 @@ function runOperationInterceptors(
 ): Promise<void> {
   const promises = _.map(
     operationInterceptors[trigger],
-    interceptor => Promise.resolve()
-      .then(() => interceptor(op, options))
-      .then(
-        () => ({rejected: false as const}),
-        error => ({rejected: true as const, error})
-      )
+    interceptor => Promise.resolve().then(() => interceptor(op, options))
   );
-  return Promise.all(promises).then(results => {
+  return Promise.allSettled(promises).then(results => {
     for (const result of results) {
-      if (result.rejected) throw result.error;
+      if (result.status === 'rejected') throw result.reason;
     }
   });
 }

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -24,13 +24,16 @@ const {default: NodeFire} = require('../built/index.js');
 let appCounter = 0;
 let beforeInterceptor = _.noop;
 let afterInterceptor = _.noop;
+let laterAfterInterceptor = _.noop;
 
 NodeFire.interceptOperations((...args) => beforeInterceptor(...args));
 NodeFire.interceptOperations((...args) => afterInterceptor(...args), 'after');
+NodeFire.interceptOperations((...args) => laterAfterInterceptor(...args), 'after');
 
 function resetInterceptors() {
   beforeInterceptor = _.noop;
   afterInterceptor = _.noop;
+  laterAfterInterceptor = _.noop;
 }
 
 class FakeReference {
@@ -134,13 +137,16 @@ test('after interceptors observe operation errors without replacing them', async
   assert.strictEqual(observedError, operationError);
 });
 
-test('after interceptor failures propagate from successful operations', async t => {
+test('after interceptor failures propagate without blocking later interceptors', async t => {
   t.after(resetInterceptors);
   const interceptorError = new Error('observer failed');
+  let laterCalled = false;
   afterInterceptor = () => {throw interceptorError;};
+  laterAfterInterceptor = () => {laterCalled = true;};
 
   const ref = new NodeFire(new FakeReference('/writes'));
   await assert.rejects(ref.set('value'), error => error === interceptorError);
+  assert.strictEqual(laterCalled, true);
 });
 
 test('permission diagnostics do not add to operation duration', async t => {

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -137,16 +137,35 @@ test('after interceptors observe operation errors without replacing them', async
   assert.strictEqual(observedError, operationError);
 });
 
-test('after interceptor failures propagate without blocking later interceptors', async t => {
+test('after interceptor failures wait for later interceptors before propagating', async t => {
   t.after(resetInterceptors);
   const interceptorError = new Error('observer failed');
   let laterCalled = false;
+  let resolveLater;
+  const laterReady = new Promise(resolve => {resolveLater = resolve;});
   afterInterceptor = () => {throw interceptorError;};
-  laterAfterInterceptor = () => {laterCalled = true;};
+  laterAfterInterceptor = () => {
+    laterCalled = true;
+    return laterReady;
+  };
 
   const ref = new NodeFire(new FakeReference('/writes'));
-  await assert.rejects(ref.set('value'), error => error === interceptorError);
+  let settled = false;
+  let rejection;
+  const promise = ref.set('value');
+  const observedPromise = promise.then(
+    () => {settled = true;},
+    error => {
+      settled = true;
+      rejection = error;
+    }
+  );
+  await new Promise(resolve => setImmediate(resolve));
   assert.strictEqual(laterCalled, true);
+  assert.strictEqual(settled, false);
+  resolveLater();
+  await observedPromise;
+  assert.strictEqual(rejection, interceptorError);
 });
 
 test('permission diagnostics do not add to operation duration', async t => {

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import {performance} from 'node:perf_hooks';
+import {test} from 'node:test';
+import {setImmediate, setTimeout} from 'node:timers';
+
+import _ from 'lodash';
+
+import NodeFireModule from '../built/index.js';
+
+const {default: NodeFire} = NodeFireModule;
+let appCounter = 0;
+
+class FakeReference {
+  constructor(path = '/', operations = {}, database = {
+    app: {name: `operations-test-${++appCounter}`, options: {}}
+  }) {
+    this.path = path;
+    this.operations = operations;
+    this.database = database;
+  }
+
+  get key() {
+    return this.path === '/' ? null : this.path.slice(this.path.lastIndexOf('/') + 1);
+  }
+
+  get ref() {
+    return this;
+  }
+
+  get root() {
+    return new FakeReference('/', this.operations, this.database);
+  }
+
+  child(path) {
+    return new FakeReference(
+      `${this.path === '/' ? '' : this.path}/${path}`, this.operations, this.database);
+  }
+
+  isEqual(other) {
+    return this.database === other.database && this.path === other.path;
+  }
+
+  on(event, callback) {
+    if (_.endsWith(this.path, '/.info/serverTimeOffset')) callback({val: _.constant(0)});
+    if (_.endsWith(this.path, '/.info/connected')) callback({val: _.constant(true)});
+  }
+
+  off() {/* Nothing to detach in the fake reference. */}
+
+  set(value) {
+    return this.operations.set?.(value) ?? Promise.resolve();
+  }
+
+  transaction(updateFunction, callback) {
+    return this.operations.transaction?.(updateFunction, callback) ?? Promise.resolve();
+  }
+
+  toString() {
+    return `https://operations.test${this.path}`;
+  }
+}
+
+test('before and after interceptors share the descriptor and wait for promises', async () => {
+  let resolveAfter;
+  const afterReady = new Promise(resolve => {resolveAfter = resolve;});
+  let beforeDescriptor;
+  let afterDescriptor;
+  const stopBefore = NodeFire.interceptOperations((op, options) => {
+    beforeDescriptor = op;
+    options.fromBefore = true;
+  });
+  const stopAfter = NodeFire.interceptOperations(async (op, options) => {
+    afterDescriptor = op;
+    assert.strictEqual(options.fromBefore, true);
+    await afterReady;
+  }, 'after');
+
+  try {
+    const ref = new NodeFire(new FakeReference('/writes'));
+    let settled = false;
+    const promise = ref.set('value').then(() => {settled = true;});
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(settled, false);
+    assert.strictEqual(afterDescriptor, beforeDescriptor);
+    assert.strictEqual(afterDescriptor.method, 'set');
+    assert.deepStrictEqual(afterDescriptor.args, ['value']);
+    assert.strictEqual(afterDescriptor.error, undefined);
+    assert.ok(afterDescriptor.duration >= 0);
+    assert.ok(afterDescriptor.startTime <= performance.now());
+    resolveAfter();
+    await promise;
+  } finally {
+    stopBefore();
+    stopAfter();
+  }
+});
+
+test('after interceptors observe operation errors without replacing them', async () => {
+  const operationError = new Error('write failed');
+  let observedError;
+  const stopAfter = NodeFire.interceptOperations(op => {
+    observedError = op.error;
+    throw new Error('observer failed');
+  }, 'after');
+
+  try {
+    const ref = new NodeFire(new FakeReference('/writes', {
+      set: () => Promise.reject(operationError)
+    }));
+    await assert.rejects(ref.set('value'), error => {
+      assert.strictEqual(error, operationError);
+      assert.strictEqual(error.cause?.message, 'observer failed');
+      return true;
+    });
+    assert.strictEqual(observedError, operationError);
+  } finally {
+    stopAfter();
+  }
+});
+
+test('transaction duration is averaged across tries', async () => {
+  let descriptor;
+  const stopAfter = NodeFire.interceptOperations(op => {descriptor = op;}, 'after');
+
+  try {
+    const ref = new NodeFire(new FakeReference('/writes', {
+      transaction: (updateFunction, callback) => {
+        updateFunction(null);
+        setTimeout(() => {
+          updateFunction(null);
+          callback(null, true, {val: _.constant('committed')});
+        }, 30);
+        return Promise.resolve();
+      }
+    }));
+    const result = await ref.transaction(_.constant('committed'), {prefetchValue: false});
+    assert.strictEqual(result, 'committed');
+    assert.strictEqual(descriptor.transaction.outcome, 'commit');
+    assert.strictEqual(descriptor.transaction.tries, 2);
+    assert.ok(descriptor.duration >= 10);
+    assert.ok(descriptor.duration < 30);
+  } finally {
+    stopAfter();
+  }
+});

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -209,7 +209,7 @@ test('permission diagnostics do not add to operation duration', async t => {
   assert.ok(descriptor.startTime + descriptor.duration <= permissionDiagnosticStartTime + 5);
 });
 
-test('transaction duration is averaged across tries', async t => {
+test('transaction duration spans all tries but excludes prefetch', async t => {
   t.after(resetInterceptors);
   let descriptor;
   afterInterceptor = op => {descriptor = op;};
@@ -228,8 +228,9 @@ test('transaction duration is averaged across tries', async t => {
   assert.strictEqual(result, 'committed');
   assert.strictEqual(descriptor.transaction.outcome, 'commit');
   assert.strictEqual(descriptor.transaction.tries, 2);
-  assert.ok(descriptor.duration >= 10);
-  assert.ok(descriptor.duration < 30);
+  assert.strictEqual(descriptor.transaction.prefetchDuration, undefined);
+  assert.strictEqual(descriptor.duration, descriptor.transaction.duration);
+  assert.ok(descriptor.duration >= 20);
 });
 
 test('transactions cancelled during prefetch omit operation timing', async t => {
@@ -250,6 +251,7 @@ test('transactions cancelled during prefetch omit operation timing', async t => 
   assert.strictEqual(operationCalled, false);
   assert.strictEqual(descriptor.startTime, undefined);
   assert.strictEqual(descriptor.duration, undefined);
+  assert.ok(descriptor.transaction.prefetchDuration >= 0);
   assert.strictEqual(descriptor.transaction.duration, undefined);
 });
 

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -9,6 +9,16 @@ import NodeFireModule from '../built/index.js';
 
 const {default: NodeFire} = NodeFireModule;
 let appCounter = 0;
+let beforeInterceptor = _.noop;
+let afterInterceptor = _.noop;
+
+NodeFire.interceptOperations((...args) => beforeInterceptor(...args));
+NodeFire.interceptOperations((...args) => afterInterceptor(...args), 'after');
+
+function resetInterceptors() {
+  beforeInterceptor = _.noop;
+  afterInterceptor = _.noop;
+}
 
 class FakeReference {
   constructor(path = '/', operations = {}, database = {
@@ -60,86 +70,107 @@ class FakeReference {
   }
 }
 
-test('before and after interceptors share the descriptor and wait for promises', async () => {
+test('before and after interceptors share the descriptor and wait for promises', async t => {
+  t.after(resetInterceptors);
   let resolveAfter;
   const afterReady = new Promise(resolve => {resolveAfter = resolve;});
   let beforeDescriptor;
   let afterDescriptor;
-  const stopBefore = NodeFire.interceptOperations((op, options) => {
+  beforeInterceptor = (op, options) => {
     beforeDescriptor = op;
     options.fromBefore = true;
-  });
-  const stopAfter = NodeFire.interceptOperations(async (op, options) => {
+  };
+  afterInterceptor = async (op, options) => {
     afterDescriptor = op;
     assert.strictEqual(options.fromBefore, true);
     await afterReady;
-  }, 'after');
+  };
 
-  try {
-    const ref = new NodeFire(new FakeReference('/writes'));
-    let settled = false;
-    const promise = ref.set('value').then(() => {settled = true;});
-    await new Promise(resolve => setImmediate(resolve));
-    assert.strictEqual(settled, false);
-    assert.strictEqual(afterDescriptor, beforeDescriptor);
-    assert.strictEqual(afterDescriptor.method, 'set');
-    assert.deepStrictEqual(afterDescriptor.args, ['value']);
-    assert.strictEqual(afterDescriptor.error, undefined);
-    assert.ok(afterDescriptor.duration >= 0);
-    assert.ok(afterDescriptor.startTime <= performance.now());
-    resolveAfter();
-    await promise;
-  } finally {
-    stopBefore();
-    stopAfter();
-  }
+  const ref = new NodeFire(new FakeReference('/writes'));
+  let settled = false;
+  const promise = ref.set('value').then(() => {settled = true;});
+  await new Promise(resolve => setImmediate(resolve));
+  assert.strictEqual(settled, false);
+  assert.strictEqual(afterDescriptor, beforeDescriptor);
+  assert.strictEqual(afterDescriptor.method, 'set');
+  assert.deepStrictEqual(afterDescriptor.args, ['value']);
+  assert.strictEqual(afterDescriptor.error, undefined);
+  assert.ok(afterDescriptor.duration >= 0);
+  assert.ok(afterDescriptor.startTime <= performance.now());
+  resolveAfter();
+  await promise;
 });
 
-test('after interceptors observe operation errors without replacing them', async () => {
+test('after interceptors observe operation errors without replacing them', async t => {
+  t.after(resetInterceptors);
   const operationError = new Error('write failed');
   let observedError;
-  const stopAfter = NodeFire.interceptOperations(op => {
+  afterInterceptor = op => {
     observedError = op.error;
     throw new Error('observer failed');
-  }, 'after');
+  };
 
-  try {
-    const ref = new NodeFire(new FakeReference('/writes', {
-      set: () => Promise.reject(operationError)
-    }));
-    await assert.rejects(ref.set('value'), error => {
-      assert.strictEqual(error, operationError);
-      assert.strictEqual(error.cause?.message, 'observer failed');
-      return true;
-    });
-    assert.strictEqual(observedError, operationError);
-  } finally {
-    stopAfter();
-  }
+  const ref = new NodeFire(new FakeReference('/writes', {
+    set: () => Promise.reject(operationError)
+  }));
+  await assert.rejects(ref.set('value'), error => {
+    assert.strictEqual(error, operationError);
+    assert.strictEqual(error.cause?.message, 'observer failed');
+    return true;
+  });
+  assert.strictEqual(observedError, operationError);
 });
 
-test('transaction duration is averaged across tries', async () => {
-  let descriptor;
-  const stopAfter = NodeFire.interceptOperations(op => {descriptor = op;}, 'after');
+test('after interceptor failures propagate from successful operations', async t => {
+  t.after(resetInterceptors);
+  const interceptorError = new Error('observer failed');
+  afterInterceptor = () => {throw interceptorError;};
 
-  try {
-    const ref = new NodeFire(new FakeReference('/writes', {
-      transaction: (updateFunction, callback) => {
+  const ref = new NodeFire(new FakeReference('/writes'));
+  await assert.rejects(ref.set('value'), error => error === interceptorError);
+});
+
+test('transaction duration is averaged across tries', async t => {
+  t.after(resetInterceptors);
+  let descriptor;
+  afterInterceptor = op => {descriptor = op;};
+
+  const ref = new NodeFire(new FakeReference('/writes', {
+    transaction: (updateFunction, callback) => {
+      updateFunction(null);
+      setTimeout(() => {
         updateFunction(null);
-        setTimeout(() => {
-          updateFunction(null);
-          callback(null, true, {val: _.constant('committed')});
-        }, 30);
-        return Promise.resolve();
-      }
-    }));
-    const result = await ref.transaction(_.constant('committed'), {prefetchValue: false});
-    assert.strictEqual(result, 'committed');
-    assert.strictEqual(descriptor.transaction.outcome, 'commit');
-    assert.strictEqual(descriptor.transaction.tries, 2);
-    assert.ok(descriptor.duration >= 10);
-    assert.ok(descriptor.duration < 30);
-  } finally {
-    stopAfter();
-  }
+        callback(null, true, {val: _.constant('committed')});
+      }, 30);
+      return Promise.resolve();
+    }
+  }));
+  const result = await ref.transaction(_.constant('committed'), {prefetchValue: false});
+  assert.strictEqual(result, 'committed');
+  assert.strictEqual(descriptor.transaction.outcome, 'commit');
+  assert.strictEqual(descriptor.transaction.tries, 2);
+  assert.ok(descriptor.duration >= 10);
+  assert.ok(descriptor.duration < 30);
+});
+
+test('transactions blocked by before interceptors do not invoke after interceptors', async t => {
+  t.after(resetInterceptors);
+  const interceptorError = new Error('blocked');
+  let operationCalled = false;
+  let afterCalled = false;
+  beforeInterceptor = () => Promise.reject(interceptorError);
+  afterInterceptor = () => {afterCalled = true;};
+
+  const ref = new NodeFire(new FakeReference('/writes', {
+    transaction: () => {
+      operationCalled = true;
+      return Promise.resolve();
+    }
+  }));
+  await assert.rejects(
+    ref.transaction(_.constant('committed'), {prefetchValue: false}),
+    error => error === interceptorError
+  );
+  assert.strictEqual(operationCalled, false);
+  assert.strictEqual(afterCalled, false);
 });

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -1,13 +1,26 @@
 import assert from 'node:assert/strict';
+import {createRequire} from 'node:module';
 import {performance} from 'node:perf_hooks';
 import {test} from 'node:test';
 import {setImmediate, setTimeout} from 'node:timers';
 
 import _ from 'lodash';
 
-import NodeFireModule from '../built/index.js';
+const require = createRequire(import.meta.url);
+const FirefightModule = require('firefight');
+let permissionDiagnostic = Promise.resolve('permission trace');
+let permissionDiagnosticStartTime;
+FirefightModule.Simulator = class {
+  isPermissionDenied(error) {
+    return error.code === 'PERMISSION_DENIED';
+  }
 
-const {default: NodeFire} = NodeFireModule;
+  auth() {
+    permissionDiagnosticStartTime = performance.now();
+    return {set: () => permissionDiagnostic};
+  }
+};
+const {default: NodeFire} = require('../built/index.js');
 let appCounter = 0;
 let beforeInterceptor = _.noop;
 let afterInterceptor = _.noop;
@@ -128,6 +141,40 @@ test('after interceptor failures propagate from successful operations', async t 
 
   const ref = new NodeFire(new FakeReference('/writes'));
   await assert.rejects(ref.set('value'), error => error === interceptorError);
+});
+
+test('permission diagnostics do not add to operation duration', async t => {
+  t.after(resetInterceptors);
+  let resolveDiagnostic;
+  permissionDiagnostic = new Promise(resolve => {resolveDiagnostic = resolve;});
+  t.after(() => {permissionDiagnostic = Promise.resolve('permission trace');});
+  const database = {
+    app: {
+      name: `operations-test-${++appCounter}`,
+      options: {databaseAuthVariableOverride: {uid: 'test'}}
+    },
+    ref: _.constant({toString: _.constant('https://operations-test.firebaseio.com/')})
+  };
+  const permissionError = _.assign(new Error('permission_denied'), {
+    code: 'PERMISSION_DENIED'
+  });
+  const ref = new NodeFire(new FakeReference('/writes', {
+    set: () => Promise.reject(permissionError)
+  }, database));
+  ref.enablePermissionDebugging('secret');
+  t.after(() => ref.enablePermissionDebugging(null));
+  let descriptor;
+  afterInterceptor = op => {descriptor = op;};
+
+  let settled = false;
+  const promise = ref.set('value');
+  promise.then(() => {settled = true;}, () => {settled = true;});
+  await new Promise(resolve => setTimeout(resolve, 100));
+  assert.strictEqual(settled, false);
+  resolveDiagnostic('permission trace');
+  await assert.rejects(promise, error => error === permissionError);
+  assert.strictEqual(descriptor.error.firebase.permissionTrace, 'permission trace');
+  assert.ok(descriptor.startTime + descriptor.duration <= permissionDiagnosticStartTime + 5);
 });
 
 test('transaction duration is averaged across tries', async t => {

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -66,9 +66,16 @@ class FakeReference {
     return this.database === other.database && this.path === other.path;
   }
 
-  on(event, callback) {
-    if (_.endsWith(this.path, '/.info/serverTimeOffset')) callback({val: _.constant(0)});
-    if (_.endsWith(this.path, '/.info/connected')) callback({val: _.constant(true)});
+  on(event, callback, cancelCallback) {
+    if (_.endsWith(this.path, '/.info/serverTimeOffset')) {
+      callback({val: _.constant(0)});
+      return;
+    }
+    if (_.endsWith(this.path, '/.info/connected')) {
+      callback({val: _.constant(true)});
+      return;
+    }
+    this.operations.on?.(event, callback, cancelCallback);
   }
 
   off() {/* Nothing to detach in the fake reference. */}
@@ -223,6 +230,27 @@ test('transaction duration is averaged across tries', async t => {
   assert.strictEqual(descriptor.transaction.tries, 2);
   assert.ok(descriptor.duration >= 10);
   assert.ok(descriptor.duration < 30);
+});
+
+test('transactions cancelled during prefetch omit operation timing', async t => {
+  t.after(resetInterceptors);
+  const prefetchError = new Error('cancelled');
+  let descriptor;
+  let operationCalled = false;
+  afterInterceptor = op => {descriptor = op;};
+
+  const ref = new NodeFire(new FakeReference('/writes', {
+    on: (event, callback, cancelCallback) => cancelCallback(prefetchError),
+    transaction: () => {
+      operationCalled = true;
+      return Promise.resolve();
+    }
+  }));
+  await assert.rejects(ref.transaction(_.constant('committed')), error => error === prefetchError);
+  assert.strictEqual(operationCalled, false);
+  assert.strictEqual(descriptor.startTime, undefined);
+  assert.strictEqual(descriptor.duration, undefined);
+  assert.strictEqual(descriptor.transaction.duration, undefined);
 });
 
 test('transactions blocked by before interceptors do not invoke after interceptors', async t => {

--- a/tests/operations.mjs
+++ b/tests/operations.mjs
@@ -255,6 +255,35 @@ test('transactions cancelled during prefetch omit operation timing', async t => 
   assert.strictEqual(descriptor.transaction.duration, undefined);
 });
 
+test('transaction timeouts prevent a late prefetch from starting Firebase work', async t => {
+  t.after(resetInterceptors);
+  let descriptor;
+  let prefetchCallback;
+  let operationCalls = 0;
+  afterInterceptor = op => {descriptor = op;};
+
+  const ref = new NodeFire(new FakeReference('/writes', {
+    on: (event, callback) => {prefetchCallback = callback;},
+    transaction: () => {
+      operationCalls++;
+      return Promise.resolve();
+    }
+  }));
+  await assert.rejects(
+    ref.transaction(_.constant('committed'), {timeout: 10}),
+    /Firebase: timeout/
+  );
+  assert.strictEqual(operationCalls, 0);
+
+  prefetchCallback();
+  await new Promise(resolve => setImmediate(resolve));
+  assert.strictEqual(operationCalls, 0);
+  assert.strictEqual(descriptor.startTime, undefined);
+  assert.strictEqual(descriptor.duration, undefined);
+  assert.ok(descriptor.transaction.prefetchDuration >= 0);
+  assert.strictEqual(descriptor.transaction.duration, undefined);
+});
+
 test('transactions blocked by before interceptors do not invoke after interceptors', async t => {
   t.after(resetInterceptors);
   const interceptorError = new Error('blocked');

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,5 +1,8 @@
 import type {Reference} from 'firebase-admin/database';
-import NodeFire, {type CacheStats, type ChildNodeFireOf} from '../src';
+import NodeFire, {
+  type CacheStats, type ChildNodeFireOf, type InterceptOperationsCallback,
+  type OperationDescriptor, type OperationInterceptorTrigger
+} from '../src';
 
 type Equal<Left, Right> =
   (<T>() => T extends Left ? 1 : 2) extends
@@ -32,6 +35,23 @@ const unusedCacheHits: number = unusedCacheStats.hits;
 const unusedCacheMisses: number = unusedCacheStats.misses;
 const unusedCacheHitRate: number = unusedCacheStats.hitRate;
 NodeFire.resetCacheStats();
+const beforeTrigger: OperationInterceptorTrigger = 'before';
+const afterTrigger: OperationInterceptorTrigger = 'after';
+const interceptor: InterceptOperationsCallback = async (op, options) => {
+  const descriptor: OperationDescriptor = op;
+  const unusedDuration: number | undefined = descriptor.duration;
+  const unusedStartTime: number | undefined = descriptor.startTime;
+  const unusedError: unknown = descriptor.error;
+  const unusedTries: number | undefined = descriptor.transaction?.tries;
+  options.extra = true;
+  await Promise.resolve([unusedDuration, unusedStartTime, unusedError, unusedTries]);
+};
+const stopBeforeInterceptor: () => void = NodeFire.interceptOperations(interceptor, beforeTrigger);
+const stopAfterInterceptor: () => void = NodeFire.interceptOperations(interceptor, afterTrigger);
+const stopDefaultInterceptor: () => void = NodeFire.interceptOperations(interceptor);
+stopBeforeInterceptor();
+stopAfterInterceptor();
+stopDefaultInterceptor();
 type UntypedParentResult = Expect<
   Equal<GetResult<NonNullable<typeof untyped.parent>>, unknown>
 >;

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -46,12 +46,9 @@ const interceptor: InterceptOperationsCallback = async (op, options) => {
   options.extra = true;
   await Promise.resolve([unusedDuration, unusedStartTime, unusedError, unusedTries]);
 };
-const stopBeforeInterceptor: () => void = NodeFire.interceptOperations(interceptor, beforeTrigger);
-const stopAfterInterceptor: () => void = NodeFire.interceptOperations(interceptor, afterTrigger);
-const stopDefaultInterceptor: () => void = NodeFire.interceptOperations(interceptor);
-stopBeforeInterceptor();
-stopAfterInterceptor();
-stopDefaultInterceptor();
+NodeFire.interceptOperations(interceptor, beforeTrigger);
+NodeFire.interceptOperations(interceptor, afterTrigger);
+NodeFire.interceptOperations(interceptor);
 type UntypedParentResult = Expect<
   Equal<GetResult<NonNullable<typeof untyped.parent>>, unknown>
 >;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "declaration": true /* Generate declaration files alongside with js files? */,
         "outDir": "./built" /* Redirect output structure to the directory. */,
         "rootDir": "./src/" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
-        "target": "ES2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+        "target": "ES2023"
     },
     "exclude": ["./built", "./tests", "eslint.config.mjs"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "declaration": true /* Generate declaration files alongside with js files? */,
         "outDir": "./built" /* Redirect output structure to the directory. */,
-        "rootDir": "./src/" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
-        "target": "ES2023"
+        "rootDir": "./src/" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     },
     "exclude": ["./built", "./tests", "eslint.config.mjs"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3143,7 +3143,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     lru-cache: "npm:11.x"
     npm-check-updates: "npm:^22.2.9"
-    reviewable-configs: "Reviewable/reviewable-configs#master"
+    reviewable-configs: "github:Reviewable/reviewable-configs#master"
     safe-timers: "npm:^1.1.0"
     typescript: "npm:^5.4.0"
   languageName: unknown
@@ -3509,9 +3509,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reviewable-configs@Reviewable/reviewable-configs#master":
+"reviewable-configs@github:Reviewable/reviewable-configs#master":
   version: 1.0.0
-  resolution: "reviewable-configs@https://github.com/Reviewable/reviewable-configs.git#commit=417898ff0fc410e5223f84f3d5abfb6c1a947685"
+  resolution: "reviewable-configs@https://github.com/Reviewable/reviewable-configs.git#commit=f0036889d2c4a330c79d7455066832dcd0f1216a"
   dependencies:
     "@eslint/compat": "npm:^2.1.0"
     "@eslint/js": "npm:^10.0.1"
@@ -3522,7 +3522,7 @@ __metadata:
     typescript-eslint: "npm:^8.7.0"
   bin:
     reviewable-upgrade: ./bin/reviewable-upgrade.mjs
-  checksum: 10c0/e98e73d6f740f0beacd2ea482bf29022115eccf3c9bb67082955333236cdf6c878c5de8274f1b6c5003336f1605c8b7465ccb951d0eee021f236633fb870141e
+  checksum: 10c0/de45d7769872a0196c963a2848b559d544387de7550da9889b4e27980ec1dc937a108950c08f081e2881d983df8fa1bd7f645e12fa0bb0a70b2fea47a9033c0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- extend `NodeFire.interceptOperations()` with `before` and `after` triggers
- decorate completed operation descriptors with monotonic timing, errors, and transaction metadata; transaction timing excludes prefetch and spans the full transaction phase
- await completion interceptors while preserving the original operation error and attaching any interceptor failure
- prevent a timed-out transaction prefetch from starting Firebase work later
- document and type the API, target ES2023 in line with the Node 22 minimum, add focused tests, and bump NodeFire to 7.2.0

This lets consumers observe holistic Firebase write latency without issuing dedicated probes, which is needed for closed-loop load control in Firelease.

## Validation

- `yarn lint`
- `yarn check-types`
- `yarn test` (17 tests)
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/58)
<!-- Reviewable:end -->
